### PR TITLE
Fix broken help indention.

### DIFF
--- a/argvard/__init__.py
+++ b/argvard/__init__.py
@@ -342,7 +342,7 @@ class Option(object):
         if self.function.__doc__ is None:
             self.description = None
         else:
-            self.description = textwrap.dedent(self.function.__doc__.strip())
+            self.description = textwrap.dedent(self.function.__doc__).strip()
         self.signature = signature
         self.overrideable = overrideable
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -620,6 +620,8 @@ class TestHelpOption(object):
         def option(context):
             """
             A description.
+
+            Another line.
             """
         argvard.main()(lambda context: None)
         with pytest.raises(SystemExit) as exception:
@@ -635,6 +637,8 @@ class TestHelpOption(object):
             u'    Show this text.\n'
             u'--foo\n'
             u'    A description.\n'
+            u'    \n'
+            u'    Another line.\n'
         )
 
     def test_command(self, capsys, name):


### PR DESCRIPTION
Calling strip first will make the first line have an indentation of
zero, which will cause dedent to do nothing at all.
